### PR TITLE
feat(errors): Migrate package usages to v2 error package

### DIFF
--- a/Net.go
+++ b/Net.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/miekg/dns"
-	pe "github.com/qydysky/part/errors"
+	pe "github.com/qydysky/part/errors/v2"
 	pfile "github.com/qydysky/part/file"
 	psync "github.com/qydysky/part/sync"
 	us "github.com/qydysky/part/unsafe"
@@ -122,10 +122,10 @@ func connBridge(a, b net.Conn, bufSize int) {
 	b.Close()
 }
 
-var (
-	ErrForwardAccept pe.Action = `ErrForwardAccept`
-	ErrForwardDail   pe.Action = `ErrForwardDail`
-)
+var ActForward = pe.Action[struct {
+	ErrForwardAccept pe.Error
+	ErrForwardDail   pe.Error
+}](`ActForward`)
 
 type ForwardMsgFunc interface {
 	ErrorMsg(targetaddr, listenaddr string, e error)
@@ -212,7 +212,7 @@ func Forward(targetaddr, listenaddr string, acceptCIDRs []string, callBack Forwa
 			}
 			if err != nil {
 				//返回Accept错误
-				callBack.WarnMsg(targetaddr, listenaddr, pe.Join(ErrForwardAccept, err))
+				callBack.WarnMsg(targetaddr, listenaddr, pe.Join(ActForward.ErrForwardAccept, err))
 				continue
 			}
 
@@ -241,7 +241,7 @@ func Forward(targetaddr, listenaddr string, acceptCIDRs []string, callBack Forwa
 				defer conFin()
 				targetconn, err := net.Dial(tarNet, tarAddr)
 				if err != nil {
-					callBack.WarnMsg(targetaddr, listenaddr, pe.Join(ErrForwardDail, err))
+					callBack.WarnMsg(targetaddr, listenaddr, pe.Join(ActForward.ErrForwardDail, err))
 					return
 				}
 

--- a/component2/comp.go
+++ b/component2/comp.go
@@ -4,18 +4,19 @@ import (
 	"runtime"
 	"strings"
 
-	perrors "github.com/qydysky/part/errors"
+	pe "github.com/qydysky/part/errors/v2"
 	psync "github.com/qydysky/part/sync"
 )
 
 var pkgInterfaceMap = psync.NewMapG[string, any]()
 
-var (
-	ErrEmptyPkgId    = perrors.New("ErrEmptyPkgId")
-	ErrRegistered    = perrors.New("ErrRegistered")
-	ErrNoFound       = perrors.Action("ErrNoFound")
-	ErrTypeAssertion = perrors.Action("ErrTypeAssertion")
-)
+var ActComp = pe.Action[struct {
+	ErrEmptyPkgId    pe.Error
+	ErrRegistered    pe.Error
+	ErrNoFound       pe.Error
+	ErrTypeAssertion pe.Error
+	m                pe.Method
+}](`ActComp`)
 
 func PkgId(varId ...string) string {
 	if pc, _, _, ok := runtime.Caller(1); ok {
@@ -29,10 +30,10 @@ func PkgId(varId ...string) string {
 // 注册错误时，返回错误
 func Register[TargetInterface any](id string, _interface TargetInterface) error {
 	if id == "" {
-		return ErrEmptyPkgId
+		return ActComp.ErrEmptyPkgId
 	}
 	if _, ok := pkgInterfaceMap.LoadOrStore(id, _interface); ok {
-		return ErrRegistered
+		return ActComp.ErrRegistered
 	}
 	return nil
 }
@@ -48,10 +49,10 @@ func RegisterOrPanic[TargetInterface any](id string, _interface TargetInterface)
 
 func UnRegist(id string) error {
 	if id == "" {
-		return ErrEmptyPkgId
+		return ActComp.ErrEmptyPkgId
 	}
 	if _, ok := pkgInterfaceMap.LoadAndDelete(id); !ok {
-		return ErrNoFound
+		return ActComp.ErrNoFound
 	}
 	return nil
 }
@@ -137,10 +138,10 @@ func (t *GetRunner[TargetInterface]) Inter(ifFail ...func(error) TargetInterface
 	if t.err != nil {
 		if len(ifFail) == 0 {
 			p := PreFuncPanic[TargetInterface]{}
-			if ErrNoFound.Catch(t.err) {
+			if pe.Is(t.err, ActComp.ErrNoFound) {
 				_ = p.ErrNoFound(t.cmpid)
 			}
-			if ErrTypeAssertion.Catch(t.err) {
+			if pe.Is(t.err, ActComp.ErrTypeAssertion) {
 				_ = p.ErrTypeAssertion(t.cmpid)
 			}
 			panic(t.cmpid)
@@ -189,11 +190,11 @@ func (PreFuncPanic[TargetInterface]) Init(s TargetInterface) TargetInterface {
 }
 
 func (PreFuncPanic[TargetInterface]) ErrNoFound(id string) error {
-	panic(perrors.ErrorFormat(ErrNoFound.New(id), perrors.ErrActionInLineFunc))
+	panic(pe.ErrorFormat(ActComp.ErrNoFound.Raw(id), pe.ErrActionInLineFunc))
 }
 
 func (PreFuncPanic[TargetInterface]) ErrTypeAssertion(id string) error {
-	panic(perrors.ErrorFormat(ErrTypeAssertion.New(id), perrors.ErrActionInLineFunc))
+	panic(pe.ErrorFormat(ActComp.ErrTypeAssertion.Raw(id), pe.ErrActionInLineFunc))
 }
 
 type PreFuncErr[TargetInterface any] struct{}
@@ -203,11 +204,11 @@ func (PreFuncErr[TargetInterface]) Init(s TargetInterface) TargetInterface {
 }
 
 func (PreFuncErr[TargetInterface]) ErrNoFound(id string) error {
-	return ErrNoFound.New(id)
+	return ActComp.ErrNoFound.Raw(id)
 }
 
 func (PreFuncErr[TargetInterface]) ErrTypeAssertion(id string) error {
-	return ErrTypeAssertion.New(id)
+	return ActComp.ErrTypeAssertion.Raw(id)
 }
 
 type PreFuncCu[TargetInterface any] struct {
@@ -227,7 +228,7 @@ func (t PreFuncCu[TargetInterface]) ErrNoFound(id string) error {
 	if t.ErrNoFoundf != nil {
 		return t.ErrNoFoundf(id)
 	} else {
-		return ErrNoFound.New(id)
+		return ActComp.ErrNoFound.Raw(id)
 	}
 }
 
@@ -235,6 +236,6 @@ func (t PreFuncCu[TargetInterface]) ErrTypeAssertion(id string) error {
 	if t.ErrTypeAssertionf != nil {
 		return t.ErrTypeAssertionf(id)
 	} else {
-		return ErrTypeAssertion.New(id)
+		return ActComp.ErrTypeAssertion.Raw(id)
 	}
 }

--- a/component2/comp_test.go
+++ b/component2/comp_test.go
@@ -19,7 +19,7 @@ func Test5(t *testing.T) {
 		panic(e)
 	}
 
-	if UnRegist("aa-5") != ErrNoFound {
+	if UnRegist("aa-5") != ActComp.ErrNoFound {
 		t.Fatal()
 	}
 
@@ -125,7 +125,7 @@ func Test2(t *testing.T) {
 		GetV2("aa21", PreFuncCu[a]{
 			ErrNoFoundf: func(id string) error {
 				ok = true
-				return ErrNoFound
+				return ActComp.ErrNoFound
 			},
 		})
 		if !ok {
@@ -138,7 +138,7 @@ func Test2(t *testing.T) {
 		GetV2("aa20", PreFuncCu[interface{ Add() }]{
 			ErrTypeAssertionf: func(id string) error {
 				ok = true
-				return ErrTypeAssertion
+				return ActComp.ErrTypeAssertion
 			},
 		})
 		if !ok {

--- a/errors/v2/error_test.go
+++ b/errors/v2/error_test.go
@@ -6,13 +6,14 @@ import (
 	"testing"
 )
 
-var bus, actM = Action[struct {
-	A Error `err:"a"`
-	B *Error
+var bus = Action[struct {
+	actM Method
+	A    Error `err:"a"`
+	B    Error
 }](`bus`)
 
 func Test1(t *testing.T) {
-	t.Log(actM.Info())
+	t.Log(bus.actM.Info())
 	t.Log(ErrorFormat(bus.A, ErrActionInLineFunc))
 	if bus.A.Error() != `a` {
 		t.Fatal()
@@ -21,13 +22,13 @@ func Test1(t *testing.T) {
 		t.Fatal()
 	}
 	a := error(bus.A)
-	if !actM.InAction(a) {
+	if !bus.actM.InAction(a) {
 		t.Fatal()
 	}
 	if !errors.Is(a, bus.A) {
 		t.Fatal()
 	}
-	if actM.InAction(io.EOF) {
+	if bus.actM.InAction(io.EOF) {
 		t.Fatal()
 	}
 	b := errors.Join(io.EOF, bus.A, io.EOF)
@@ -35,41 +36,44 @@ func Test1(t *testing.T) {
 	if !errors.Is(b, bus.A) {
 		t.Fatal()
 	}
-	if !actM.InAction(b) {
+	if !bus.actM.InAction(b) {
 		t.Fatal()
 	}
 	b = errors.Join(b, io.EOF)
-	if !actM.InAction(b) {
+	if !bus.actM.InAction(b) {
 		t.Fatal()
 	}
 }
 
 func Test2(t *testing.T) {
-	bus, actM := Action[struct {
-		B Error
+	bus := Action[struct {
+		actM Method
+		B    Error
 	}](`bus`)
-	bus2, actM2 := Action[struct {
-		C Error
+	bus2 := Action[struct {
+		actM2 Method
+		C     Error
 	}](`bus2`)
 	b := errors.Join(bus.B, bus2.C)
-	if !actM2.InAction(b) {
+	if !bus2.actM2.InAction(b) {
 		t.Fatal()
 	}
-	if !actM.InAction(b) {
+	if !bus.actM.InAction(b) {
 		t.Fatal()
 	}
 }
 
 func Test3(t *testing.T) {
-	bus, actM := Action[struct {
-		B Error
+	bus := Action[struct {
+		actM Method
+		B    Error
 	}](`bus`)
 	a := Join(bus.B.Raw("we"), io.EOF)
 	t.Log(ErrorFormat(a, ErrActionInLineFunc))
-	if !actM.InAction(bus.B) {
+	if !bus.actM.InAction(bus.B) {
 		t.Fatal()
 	}
-	if !actM.InAction(a) {
+	if !bus.actM.InAction(a) {
 		t.Fatal()
 	}
 	if !errors.Is(a, bus.B) {
@@ -89,19 +93,48 @@ func Test3(t *testing.T) {
 	if !errors.Is(c, bus.B) {
 		t.Fatal()
 	}
-	if !actM.InAction(c) {
+	if !bus.actM.InAction(c) {
 		t.Fatal()
 	}
 }
 
 func Benchmark1(b *testing.B) {
-	a1, a1M := Action[struct {
-		A Error
+	a1 := Action[struct {
+		actM Method
+		A    Error
 	}](`a1`)
 	err := errors.Join(a1.A, io.EOF)
 	for b.Loop() {
-		if !a1M.InAction(err) {
+		if !bus.actM.InAction(err) {
 			b.Fatal()
 		}
+	}
+}
+
+func Test4(t *testing.T) {
+	bus := Action[struct {
+		actM Method
+		B    Error
+	}](`bus`)
+	b := bus.B.Raw("1")
+	_ = bus.B.Raw("2")
+	if b.Error() != "B:1" {
+		t.Fatal(b)
+	}
+	if !errors.Is(b, bus.B) {
+		t.Fatal()
+	}
+	var a = Error{
+		fieldName: bus.B.fieldName,
+		raw:       bus.B.raw,
+		point:     bus.B.point,
+		actRaw:    bus.B.actRaw,
+		actPoint:  bus.B.actPoint,
+	}
+	if !bus.actM.InAction(a) {
+		t.Fatal()
+	}
+	if !errors.Is(a, bus.B) {
+		t.Fatal()
 	}
 }

--- a/errors/v2/errors.go
+++ b/errors/v2/errors.go
@@ -20,7 +20,10 @@ type Error struct {
 	actPoint  uintptr
 }
 
-func (t *Error) Raw(raw string) *Error {
+// Raw will alloc new Error, which field raw is replaced, but keep other fields.
+//
+// so errors.Is or Method.IsAction will work fine, but == not
+func (t Error) Raw(raw string) Error {
 	t.raw = raw
 	return t
 }
@@ -50,10 +53,22 @@ func (t Error) Error() (e string) {
 	return
 }
 
-func Action[T any](actName string) (act *T, actM ActionMethod) {
+// T is a struct which have Fields with type Error or Method,eg.
+//
+//	xxx := Action[struct{
+//		A Error
+//		b Error
+//		m Method
+//	}](`xxx`)
+//
+// func will use reflect to init these Fields
+//
+// then use like xxx.A as normal error
+func Action[T any](actName string) (act *T) {
 	act = new(T)
 	for s, v := range reflect.ValueOf(act).Elem().Fields() {
-		if _, ok := v.Interface().(Error); ok {
+		switch s.Type {
+		case reflect.TypeFor[Error]():
 			if tagErr := s.Tag.Get(`err`); tagErr != "" {
 				reflect.NewAt(reflect.TypeFor[string](), unsafe.Pointer(v.FieldByName("fieldName").UnsafeAddr())).Elem().Set(reflect.ValueOf(tagErr))
 			} else {
@@ -62,37 +77,28 @@ func Action[T any](actName string) (act *T, actM ActionMethod) {
 			reflect.NewAt(reflect.TypeFor[string](), unsafe.Pointer(v.FieldByName("actRaw").UnsafeAddr())).Elem().Set(reflect.ValueOf(actName))
 			reflect.NewAt(reflect.TypeFor[uintptr](), unsafe.Pointer(v.FieldByName("actPoint").UnsafeAddr())).Elem().Set(reflect.ValueOf(uintptr(reflect.ValueOf(act).UnsafePointer())))
 			reflect.NewAt(reflect.TypeFor[uintptr](), unsafe.Pointer(v.FieldByName("point").UnsafeAddr())).Elem().Set(reflect.ValueOf(v.UnsafeAddr()))
-		}
-		if _, ok := v.Interface().(*Error); ok {
-			v.Set(reflect.ValueOf(new(Error)))
-			if tagErr := s.Tag.Get(`err`); tagErr != "" {
-				reflect.NewAt(reflect.TypeFor[string](), unsafe.Pointer(v.Elem().FieldByName("fieldName").UnsafeAddr())).Elem().Set(reflect.ValueOf(tagErr))
-			} else {
-				reflect.NewAt(reflect.TypeFor[string](), unsafe.Pointer(v.Elem().FieldByName("fieldName").UnsafeAddr())).Elem().Set(reflect.ValueOf(s.Name))
+		case reflect.TypeFor[Method]():
+			if pc, file, line, ok := runtime.Caller(1); ok && !strings.HasPrefix(file, build.Default.GOROOT) {
+				reflect.NewAt(reflect.TypeFor[string](), unsafe.Pointer(v.FieldByName("actLoc").UnsafeAddr())).Elem().Set(reflect.ValueOf(fmt.Sprintf("%s:%d", runtime.FuncForPC(pc).Name(), line)))
 			}
-			reflect.NewAt(reflect.TypeFor[string](), unsafe.Pointer(v.Elem().FieldByName("actRaw").UnsafeAddr())).Elem().Set(reflect.ValueOf(actName))
-			reflect.NewAt(reflect.TypeFor[uintptr](), unsafe.Pointer(v.Elem().FieldByName("actPoint").UnsafeAddr())).Elem().Set(reflect.ValueOf(uintptr(reflect.ValueOf(act).UnsafePointer())))
-			reflect.NewAt(reflect.TypeFor[uintptr](), unsafe.Pointer(v.Elem().FieldByName("point").UnsafeAddr())).Elem().Set(reflect.ValueOf(v.Elem().UnsafeAddr()))
+			reflect.NewAt(reflect.TypeFor[string](), unsafe.Pointer(v.FieldByName("actRaw").UnsafeAddr())).Elem().Set(reflect.ValueOf(actName))
+			reflect.NewAt(reflect.TypeFor[uintptr](), unsafe.Pointer(v.FieldByName("actPoint").UnsafeAddr())).Elem().Set(reflect.ValueOf(uintptr(reflect.ValueOf(act).UnsafePointer())))
 		}
-	}
-	actM = ActionMethod{actRaw: actName, actPoint: uintptr(unsafe.Pointer(act))}
-	if pc, file, line, ok := runtime.Caller(1); ok && !strings.HasPrefix(file, build.Default.GOROOT) {
-		actM.actLoc = fmt.Sprintf("%s:%d", runtime.FuncForPC(pc).Name(), line)
 	}
 	return
 }
 
-type ActionMethod struct {
+type Method struct {
 	actLoc   string
 	actRaw   string
 	actPoint uintptr
 }
 
-func (t *ActionMethod) Info() (raw, loc string) {
+func (t *Method) Info() (raw, loc string) {
 	return t.actRaw, t.actLoc
 }
 
-func (t *ActionMethod) InAction(err error) bool {
+func (t *Method) InAction(err error) bool {
 	for {
 		switch x := err.(type) {
 		case Error:

--- a/file/FileWR.go
+++ b/file/FileWR.go
@@ -13,7 +13,7 @@ import (
 	"syscall"
 	"time"
 
-	pe "github.com/qydysky/part/errors"
+	pe "github.com/qydysky/part/errors/v2"
 	pio "github.com/qydysky/part/io"
 	encoder "golang.org/x/text/encoding"
 )

--- a/io/io.go
+++ b/io/io.go
@@ -9,7 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	pe "github.com/qydysky/part/errors"
+	pe "github.com/qydysky/part/errors/v2"
 )
 
 // no close rc any time

--- a/keyFunc/keyFunc.go
+++ b/keyFunc/keyFunc.go
@@ -4,12 +4,15 @@ import (
 	"errors"
 	"iter"
 
-	perrors "github.com/qydysky/part/errors"
+	pe "github.com/qydysky/part/errors/v2"
 )
 
 var (
-	ErrNextMethod   = perrors.Action(`ErrNextMethod`)
-	ErrKeyNotValid  = perrors.Action(`ErrKeyNotValid`)
+	ActKeyFunc = pe.Action[struct {
+		ErrNextMethod  pe.Error
+		ErrKeyNotValid pe.Error
+		M              pe.Method
+	}](`ActKeyFunc`)
 	ErrKeyMissAgain = errors.New(`ErrKeyMissAgain`)
 	ErrKeyNotReg    = errors.New(`ErrKeyNotReg`)
 )
@@ -33,8 +36,8 @@ func NewKeyFunc() *KeyFunc {
 // fs func() (misskeys string, err error):
 //
 //   - 若缺失依赖key,应返回misskey!=""
-//   - 若方法错误，但不是严重错误，应返回misskey=="" err==ErrNextMethod.NewErr(err)，以便尝试下一个fs，
-//     当没有下个fs时，将会退出并返回ErrNextMethod.NewErr(err)，可以使用errors.Is比较err，也可以使用ErrNextMethod.catch捕获到ErrNextMethod
+//   - 若方法错误，但不是严重错误，应返回misskey=="" err==ActKeyFunc.ErrNextMethod，以便尝试下一个fs，
+//     当没有下个fs时，将会退出并返回ActKeyFunc.ErrNextMethod，可以使用errors.Is比较err，也可以捕获ErrNextMethod
 //   - 若方法错误，需要立即退出，应返回misskey=="" err!=nil
 //   - 其他情况，应返回misskey=="" err==nil
 func (t *KeyFunc) Reg(key string, checkf func() bool, fs ...func() (misskey string, err error)) *KeyFunc {
@@ -154,9 +157,9 @@ func (t *KeyFunc) getTrace(key string, trace *Node) *Node {
 				if t.keyCheck[key]() {
 					return trace
 				} else {
-					trace.Err = ErrKeyNotValid.NewErr(trace.Err)
+					trace.Err = pe.Join(ActKeyFunc.ErrKeyNotValid, trace.Err)
 				}
-			} else if perrors.Catch(trace.Err, ErrNextMethod) {
+			} else if pe.Is(trace.Err, ActKeyFunc.ErrNextMethod) {
 				continue
 			} else {
 				return trace

--- a/keyFunc/keyFunc_test.go
+++ b/keyFunc/keyFunc_test.go
@@ -3,6 +3,8 @@ package part
 import (
 	"errors"
 	"testing"
+
+	pe "github.com/qydysky/part/errors/v2"
 )
 
 func TestMain(t *testing.T) {
@@ -31,7 +33,7 @@ func TestMain(t *testing.T) {
 	}, func() (misskey string, err error) {
 		t.Log(`id2 1`)
 		// some method get id2 but wrong
-		return "", ErrNextMethod
+		return "", ActKeyFunc.ErrNextMethod
 	}, func() (misskey string, err error) {
 		t.Log(`id2 2`)
 		// some method get id2
@@ -72,7 +74,7 @@ func TestMain2(t *testing.T) {
 		return M.id2 != 0
 	}, func() (misskey string, err error) {
 		// some method get id2 but wrong
-		return "", ErrNextMethod
+		return "", ActKeyFunc.ErrNextMethod
 	}, func() (misskey string, err error) {
 		// some method get id2
 		M.id2 = 1
@@ -112,7 +114,7 @@ func TestMain3(t *testing.T) {
 		return M.id2 != 0
 	}, func() (misskey string, err error) {
 		// some method get id2 but wrong
-		return "", ErrNextMethod
+		return "", ActKeyFunc.ErrNextMethod
 	}, func() (misskey string, err error) {
 		// some method get id2 but wrong
 		return "", errors.New(`wrong`)
@@ -242,7 +244,7 @@ func TestMain6(t *testing.T) {
 		return M.id2 != 0
 	}, func() (misskey string, err error) {
 		// some method get id2 but wrong
-		return "", ErrNextMethod.NewErr(ccc)
+		return "", pe.Join(ActKeyFunc.ErrNextMethod, ccc)
 	}, func() (misskey string, err error) {
 		// some method get id2 but id2 not get
 		M.id2 = 0
@@ -259,11 +261,11 @@ func TestMain6(t *testing.T) {
 		}
 	}
 
-	if !ErrKeyNotValid.Catch(lastNode.Err) {
+	if !pe.Is(lastNode.Err, ActKeyFunc.ErrKeyNotValid) {
 		t.Fatal()
 	}
 
-	if !ErrKeyNotValid.Catch(api.Get(`id1`)) {
+	if !pe.Is(api.Get(`id1`), ActKeyFunc.ErrKeyNotValid) {
 		t.Fatal()
 	}
 
@@ -386,9 +388,9 @@ func TestMain9(t *testing.T) {
 	}).Reg(`id2`, func() bool {
 		return M.id2 != 0
 	}, func() (misskey string, err error) {
-		return "", ErrNextMethod.New("1")
+		return "", ActKeyFunc.ErrNextMethod.Raw("1")
 	}, func() (misskey string, err error) {
-		return "", ErrNextMethod.NewErr(ccc)
+		return "", pe.Join(ActKeyFunc.ErrNextMethod, ccc)
 	})
 
 	lastNode := api.GetTrace(`id1`)
@@ -424,7 +426,7 @@ func TestMain10(t *testing.T) {
 
 	lastNode := api.GetTrace(`id1`)
 	for node := range lastNode.Asc() {
-		if node.Key == `id1` && node.MethodIndex == 0 && !errors.Is(node.Err, ErrKeyNotValid) && !ErrKeyNotValid.Catch(node.Err) {
+		if node.Key == `id1` && node.MethodIndex == 0 && !errors.Is(node.Err, ActKeyFunc.ErrKeyNotValid) && !pe.Is(node.Err, ActKeyFunc.ErrKeyNotValid) {
 			t.Fatal()
 		}
 		t.Log(node)

--- a/reqf/Reqf.go
+++ b/reqf/Reqf.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/dustin/go-humanize"
 	br "github.com/qydysky/brotli"
-	pe "github.com/qydysky/part/errors"
+	pe "github.com/qydysky/part/errors/v2"
 	pio "github.com/qydysky/part/io"
 	prand "github.com/qydysky/part/rand"
 	// "encoding/binary"
@@ -77,14 +77,16 @@ const (
 )
 
 var (
-	ErrEmptyUrl         = pe.Action("ErrEmptyUrl")
-	ErrCantRetry        = pe.Action("ErrCantRetry")
-	ErrNewRequest       = pe.Action("ErrNewRequest")
-	ErrClientDo         = pe.Action("ErrClientDo")
-	ErrResponFileCreate = pe.Action("ErrResponFileCreate")
-	ErrCopyRes          = pe.Action("ErrCopyRes")
-	ErrPostStrOrRawPipe = pe.Action("ErrPostStrOrRawPipe")
-	ErrNoDate           = pe.Action("ErrNoDate")
+	ActReq = pe.Action[struct {
+		ErrEmptyUrl         pe.Error
+		ErrCantRetry        pe.Error
+		ErrNewRequest       pe.Error
+		ErrClientDo         pe.Error
+		ErrResponFileCreate pe.Error
+		ErrCopyRes          pe.Error
+		ErrPostStrOrRawPipe pe.Error
+		ErrNoDate           pe.Error
+	}](`ActReq`)
 )
 
 type Req struct {
@@ -245,7 +247,7 @@ func (t *Req) reqfM(ctx context.Context, ctxf1 context.CancelCauseFunc, val Rval
 func (t *Req) reqf(ctx context.Context, val Rval) (err error) {
 	req, e := http.NewRequestWithContext(ctx, val.Method, val.Url, t.reqBody)
 	if e != nil {
-		return pe.Join(ErrNewRequest.New(), e)
+		return pe.Join(ActReq.ErrNewRequest, e)
 	}
 
 	for _, v := range val.Cookies {
@@ -280,7 +282,7 @@ func (t *Req) reqf(ctx context.Context, val Rval) (err error) {
 	resp, e := t.client.Do(req)
 
 	if e != nil {
-		return pe.Join(ErrClientDo.New(), e)
+		return pe.Join(ActReq.ErrClientDo, e)
 	}
 	defer resp.Body.Close()
 
@@ -303,7 +305,7 @@ func (t *Req) reqf(ctx context.Context, val Rval) (err error) {
 		t.responFile, e = os.Create(val.SaveToPath)
 		if e != nil {
 			t.responFile.Close()
-			return pe.Join(err, ErrResponFileCreate.New(), e)
+			return pe.Join(err, ActReq.ErrResponFileCreate, e)
 		}
 		ws = append(ws, t.responFile)
 	}
@@ -405,15 +407,15 @@ func (t *Req) prepareRes() (e error) {
 
 func (t *Req) prepare(val *Rval) (ctx1 context.Context, ctxf1 context.CancelCauseFunc, e error) {
 	if val.Url == "" {
-		e = ErrEmptyUrl.New()
+		e = ActReq.ErrEmptyUrl
 		return
 	}
 	if len(val.PostStr) > 0 && val.RawPipe != nil {
-		e = ErrPostStrOrRawPipe.New()
+		e = ActReq.ErrPostStrOrRawPipe
 		return
 	}
 	if val.Retry != 0 && val.RawPipe != nil {
-		e = ErrCantRetry.New()
+		e = ActReq.ErrCantRetry
 		return
 	}
 	t.UsedTime = 0
@@ -538,7 +540,7 @@ func (t *Req) prepare(val *Rval) (ctx1 context.Context, ctxf1 context.CancelCaus
 		go func() {
 			select {
 			case <-t.rwTO.C:
-				ctxf1(ErrCopyRes)
+				ctxf1(ActReq.ErrCopyRes)
 			case <-ctx1.Done():
 			}
 		}()
@@ -590,10 +592,10 @@ func ToForm(m map[string]string) (postStr string, contentType string) {
 
 func ResDate(res *http.Response) (time.Time, error) {
 	if res == nil {
-		return time.Time{}, ErrNoDate.New()
+		return time.Time{}, ActReq.ErrNoDate
 	} else if date := res.Header.Get("date"); date != `` {
 		return time.Parse(time.RFC1123, date)
 	} else {
-		return time.Time{}, ErrNoDate.New()
+		return time.Time{}, ActReq.ErrNoDate
 	}
 }

--- a/reqf/Reqf_test.go
+++ b/reqf/Reqf_test.go
@@ -273,7 +273,7 @@ func Test15(t *testing.T) {
 		}
 	}
 
-	if !errors.Is(reuse.Wait(), ErrCopyRes) {
+	if !errors.Is(reuse.Wait(), ActReq.ErrCopyRes) {
 		t.Fatal()
 	}
 }

--- a/slice/Slice.go
+++ b/slice/Slice.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 	"time"
 	"unsafe"
-
-	perrors "github.com/qydysky/part/errors"
 )
 
 type Buf[T any] struct {
@@ -78,7 +76,7 @@ func (t *Buf[T]) AppendTo(to *Buf[T]) error {
 	return to.Append(t.GetPureBuf())
 }
 
-var ErrOverMax = perrors.New("slices.Append", "ErrOverMax")
+var ErrOverMax = errors.New("slices.Append.ErrOverMax")
 
 func (t *Buf[T]) Cap() int {
 	return cap(t.buf)
@@ -136,7 +134,7 @@ func (t *Buf[T]) SetFrom(data []T) error {
 	return nil
 }
 
-var ErrOverLen = perrors.New("slices.Remove", "ErrOverLen")
+var ErrOverLen = errors.New("slices.Remove.ErrOverLen")
 
 func (t *Buf[T]) RemoveFront(n int) error {
 	if n <= 0 {
@@ -180,7 +178,7 @@ func (t *Buf[T]) GetModified() Modified {
 	return t.modified
 }
 
-var ErrNoSameBuf = perrors.New("slices.HadModified", "ErrNoSameBuf")
+var ErrNoSameBuf = errors.New("slices.HadModified.ErrNoSameBuf")
 
 func (t *Buf[T]) HadModified(mt Modified) (modified bool, err error) {
 	if t.modified.p != mt.p {

--- a/slice/SliceIndex.go
+++ b/slice/SliceIndex.go
@@ -1,14 +1,13 @@
 package part
 
 import (
+	"errors"
 	"io"
 	"iter"
 	"sync"
-
-	perrors "github.com/qydysky/part/errors"
 )
 
-var ErrNoSameSliceIndex = perrors.New("SliceIndex.HadModified", "ErrNoSameSliceIndex")
+var ErrNoSameSliceIndex = errors.New("SliceIndex.HadModified.ErrNoSameSliceIndex")
 
 type SliceIndexModified struct {
 	p uintptr

--- a/websocket/Recoder.go
+++ b/websocket/Recoder.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/dustin/go-humanize"
 	ctx "github.com/qydysky/part/ctx"
-	pe "github.com/qydysky/part/errors"
+	pe "github.com/qydysky/part/errors/v2"
 	file "github.com/qydysky/part/file"
 	funcCtrl "github.com/qydysky/part/funcCtrl"
 	us "github.com/qydysky/part/unsafe"
@@ -86,11 +86,10 @@ func Play(filePath string) (s *Server, close func()) {
 	})
 }
 
-var (
-	ErrPlays       = pe.Action(`Plays`)
-	ErrCallPlay    = ErrPlays.New(`ErrCallPlay`)
-	ErrFileNoExist = ErrPlays.New(`ErrFileNoExist`)
-)
+var ActPlays = pe.Action[struct {
+	ErrCallPlay    pe.Error
+	ErrFileNoExist pe.Error
+}](`ActPlays`)
 
 // 当新连接建立时，总是从开头开始
 //
@@ -143,7 +142,7 @@ func Plays(regF func(reg func(filepath string, start, dur time.Duration) error))
 		var tmp *rec = rootRec
 		regF(func(filepath string, start, dur time.Duration) error {
 			if !file.IsExist(filepath) {
-				return ErrFileNoExist
+				return ActPlays.ErrFileNoExist
 			}
 			_ = rangeRec(func(r *rec) (stop bool) {
 				tmp.op += r.dur - r.start


### PR DESCRIPTION
Updates multiple packages (Net, component2, file, io, keyFunc) to use the updated error package path from `github.com/qydysky/part/errors` to `github.com/qydysky/part/errors/v2`.

Additionally, this commit refactors the initialization of action errors in `Net.go` and `component2/comp.go` to use a more structured approach with new structs containing the respective error types, and also renames `ActionMethod` to `Method` to align with the new error package structure.